### PR TITLE
Enable jwt and naive verify based on passport. Disable session for passport.

### DIFF
--- a/service/app.js
+++ b/service/app.js
@@ -7,20 +7,49 @@ const bodyparser = require('koa-bodyparser')
 const logger = require('koa-logger')
 
 // enale session by koa-session
-const session = require('koa-session')
-app.keys = ['some secret']
-const conf = {
-  encode: json => JSON.stringify(json),
-  decode: str => JSON.parse(str)
-}
-app.use(session(conf, app))
+// const session = require('koa-session')
+// app.keys = ['some secret']
+// const conf = {
+//   encode: json => JSON.stringify(json),
+//   decode: str => JSON.parse(str)
+// }
+// app.use(session(conf, app))
 
 // enale passport for user login authenticated
-const passport = require('./passport/passport')  // require koa-passport from self config file passport.js
+
+
+// 调用use()来为passport新增一个可用的策略
+const passport = require('./passport/passport')
+const jwtStrategy = require('./passport/strategy/jwt')
+const navieStrategy = require('./passport/strategy/naive')
 app.use(passport.initialize())
-app.use(passport.session())
-const naiveStrategy = require('./passport/strategy/naive')
-passport.use(naiveStrategy)   // 调用use()来为passport新增一个可用的策略
+// app.use(passport.session())
+passport.use(navieStrategy)
+passport.use(jwtStrategy)
+// 添加一个koa的中间件，使用naive策略来鉴权。这里暂不使用session
+// app.use(passport.authenticate('naive', {
+//   session: false
+// }))
+
+// 业务代码
+const Router = require('koa-router')
+const router = new Router()
+router.get('/', async (ctx) => {
+  if (ctx.isAuthenticated()) {
+    // ctx.state.user就是鉴权后得到的用户身份
+    ctx.body = 'hello ' + JSON.stringify(ctx.state.user)
+  } else {
+    ctx.throw(401)
+  }
+})
+// router.post('/login', async (ctx) => {
+//   passport.authenticate('naive', {
+//     successRedirect: '/'
+//   })
+// })
+app.use(router.routes())
+  
+
 
 // middlewares
 app.use(bodyparser({

--- a/service/passport/passport.js
+++ b/service/passport/passport.js
@@ -2,15 +2,16 @@ const passport = require('koa-passport')
 
 passport.serializeUser(function (user, done) {
     // 序列化的结果只是一个id
-    done(null, user.id)
+    done(null, user.name)
 })
 
 passport.deserializeUser(async function (str, done) {
     // 根据id恢复用户
     done(null, {
-        id: parseInt(str),
+        username: parseInt(str),
         name: 'user' + str
     })
 })
+
 
 module.exports = passport;

--- a/service/passport/strategy/jwt.js
+++ b/service/passport/strategy/jwt.js
@@ -1,44 +1,35 @@
-const JwtStrategy = require('passport-jwt').Strategy;
-const ExtractJwt = require('passport-jwt').ExtractJwt;
-const User = require('../../db/models/user')
+const jwt = require('jsonwebtoken')
+const secret = 'jwt demo'
 
-var opts = {};
-opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
-opts.secretOrKey = 'secret';
-opts.issuer = 'accounts.examplesoft.com';
-opts.audience = 'yoursite.net';
 
-const jwtStrategy = new JwtStrategy(opts, function(jwt_payload, done) {
-    User.findOne({id: jwt_payload.sub}, function(err, user) {
-        if (err) {
-            return done(err, false);
-        }
-        if (user) {
-            return done(null, user);
+// 定义一个验证用户的策略，需要定义name作为标识
+const jwtStrategy = {
+    name: 'jwt',
+    // 策略的主体就是authenticate(req)函数，在成功的时候返回用户身份，失败的时候返回错误
+    authenticate: function (ctx) {
+        const token = ctx.header.authorization // 获取jwt
+        let payload
+        if (token) {
+            payload = jwt.verify(token.split(' ')[1], secret) // // 解密，获取payload
+            this.success(payload)
         } else {
-            return done(null, false);
-            // or you could create a new account
+            this.fail(401)
         }
-    });
-});
+    }
+}
 
-// const jwtStrategy = {
-//     name: 'jwt',
-//     // 策略的主体就是authenticate(req)函数，在成功的时候返回用户身份，失败的时候返回错误
-//     authenticate: function (req) {
-//       let uid = req.query.uid
-//       if (uid) {
-//         // 策略很简单，就是从参数里获取uid，然后组装成一个user
-//         let user = {
-//           id: parseInt(uid),
-//           name: 'user' + uid
-//         }
-//         this.success(user)
-//       } else {
-//         // 如果找不到uid参数，认为鉴权失败
-//         this.fail(401)
-//       }
+
+//   let uid = req.query.uid
+//   if (uid) {
+//     // 策略很简单，就是从参数里获取uid，然后组装成一个user
+//     let user = {
+//       id: parseInt(uid),
+//       name: 'user' + uid
 //     }
-// };
+//     this.success(user)
+//   } else {
+//     // 如果找不到uid参数，认为鉴权失败
+//     this.fail(401)
+//   }
 
 module.exports = jwtStrategy;

--- a/service/routes/users.js
+++ b/service/routes/users.js
@@ -1,6 +1,7 @@
 const router = require('koa-router')()
 const User = require('../controllers/user.controller')
 const passport = require('../passport/passport')
+const secret = 'jwt demo'
 
 
 var jwt = require('jsonwebtoken');
@@ -16,7 +17,7 @@ router.post('/',  async function (ctx, next) {
   }
 })
 
-router.get('/aaa', async (ctx) => {
+router.post('/aaa', async (ctx) => {
   if (ctx.isAuthenticated()) {
     // ctx.state.user就是鉴权后得到的用户身份
     ctx.body = 'hello ' + JSON.stringify(ctx.state.user)
@@ -25,14 +26,98 @@ router.get('/aaa', async (ctx) => {
   }
 })
 
-router.get('/login',
-  passport.authenticate('naive', {
-    successRedirect: '/aaa'
+router.post('/userValidateSuccess',
+  passport.authenticate('jwt', {
+    successRedirect: '/user/bbb',
+    failureFlash: 'Invalid username or password.'
   })
 )
 
+router.post('/bbb', async (ctx) => {
+  if (ctx.isAuthenticated()) {
+    // ctx.state.user就是鉴权后得到的用户身份
+  //  ctx.body = 'hello ' + JSON.stringify(ctx.state.user)
+    ctx.body = {
+      message: '获取token成功',
+      code: 1,
+      token: ctx.header.authorization
+    }
+  } else {
+    ctx.throw(401)
+  }
+})
+
+router.post('/ccc', passport.authenticate('jwt', {}) , async (ctx) => {
+  if (ctx.isAuthenticated()) {
+    // ctx.state.user就是鉴权后得到的用户身份
+  //  ctx.body = 'hello ' + JSON.stringify(ctx.state.user)
+    ctx.body = {
+      message: '获取token成功',
+      code: 1,
+      token: ctx.header.authorization
+    }
+  } else {
+    ctx.throw(401)
+  }
+})
+
+// app.use(router.routes())
+router.post('/login', passport.authenticate('naive', {
+  // successRedirect: '/user/bbb',
+  // failureFlash: 'Invalid username or password.'
+}), async (ctx) => {
+  const user = ctx.request.body
+  if (user && user.username) {
+    let userToken = {
+      name: user.username
+    }
+    const token = jwt.sign(userToken, secret, {
+      expiresIn: '1h' //token签名 有效期为1小时
+    })
+    ctx.header.authorization = token;
+    ctx.body = {
+      message: '获取token成功',
+      code: 1,
+      token
+    }
+    // ctx.response.redirect('/user/userValidateSuccess')
+  } else {
+    ctx.body = {
+      message: '参数错误',
+      code: -1
+    }
+  }
+})
+
+// router.post('/login', 
+//   async (ctx) => {
+//     const user = ctx.request.body
+//     if (user && user.username) {
+//       let userToken = {
+//         name: user.username
+//       }
+//       const token = jwt.sign(userToken, secret, {
+//         expiresIn: '1h' //token签名 有效期为1小时
+//       })
+//       ctx.header.authorization = token;
+//       ctx.body = {
+//         message: '获取token成功',
+//         code: 1,
+//         token
+//       }
+//      ctx.response.redirect('/user/userValidateSuccess')
+//     } else {
+//       ctx.body = {
+//         message: '参数错误',
+//         code: -1
+//       }
+//     }
+//   }
+// )
+
+
 // GET /api/user/logout – clear current JWT token and logout user (Optional)
-router.get('/logout', function (ctx, next) {
+router.post('/logout', function (ctx, next) {
   ctx.logout()
   ctx.body = {
     auth: ctx.isAuthenticated(),


### PR DESCRIPTION
1. Disable session, so verify every time when call end-point. 
2. EnableJWT passport verify and Naive passport verify. Naive for /login, JWT for
/others. 
3. Need to refine code and comment later.

😖 Please note that passport-jwt strategy could not work in KOA2 framework.